### PR TITLE
clean README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,23 @@
-# Protocol team Kanban
-- [Documentation link](https://expert-journey-9jzpgrg.pages.github.io/)
-- kanban board to track `Protocol` team tasks
+<div align="center">
 
-## Team members
-- Carlos @krlosMata
-- Laia @laisolizq
-- Jesús @invocamanman
-- Ignasi @ignasirv
-- Alvaro @alrevuelta
+⬇️  ⬇️  ⬇️  ⬇️  ⬇️ 
 
-## Repositories and owners
-- [zkevm-rom](https://github.com/0xPolygon/zkevm-rom)
-- [zkevm-commonjs](https://github.com/0xPolygon/zkevm-commonjs)
-- [zkevm-testvectors](https://github.com/0xPolygon/zkevm-testvectors)
-- [zkevm-proverjs](https://github.com/0xPolygon/zkevm-proverjs)
-- [ethereumjs-monorepo](https://github.com/0xPolygon/ethereumjs-monorepo)
-- [fork ethereum-tests](https://github.com/0xPolygon/ethereum-tests)
-- [agglayer-contracts](https://github.com/agglayer/agglayer-contracts/)
+<a href="https://expert-journey-9jzpgrg.pages.github.io/" target="_blank" style="font-size:1.4em; font-weight:bold; text-decoration:none; background:#0078D7; color:white; padding:12px 20px; border-radius:8px; display:inline-block; margin:10px 0;">Access Documentation</a>  
 
-## Notion
-- [Protocol team landing page](https://www.notion.so/polygontechnology/Protocol-team-b3ee0712a65b4558910bea2ed1aecf03)
 
-## Documentation
-Documentation is available with `mkdocs`
+⬆️  ⬆️  ⬆️  ⬆️  ⬆️
 
-### How to install and run
-````
+</div>
+
+## 📑 Protocol Team Docs
+Related documentation for [Agglayer Smart Contracts](https://github.com/agglayer/agglayer-contracts) and the Agglayer protocol.
+
+## 🛠️ Build Documentation
+Documentation is available with **MkDocs**.
+
+### 🚀 How to Install and Run
+```bash
 pip install mkdocs
 pip install -r requirements.txt
 mkdocs serve
-````
-
-A bash script has been added to easily import hackmd files to the mkdocs page:
-````
-sh addHackMD.sh
-````
-
-Just follow the cli instructions, to add more paths where to store files, you should create the folders manually directly inside the `/docs` path.
-Adding files manually is also supported
+```  

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,41 +1,12 @@
-# Team protocol documentation page
+## 📑 Protocol Team Docs
+Related documentation for [Agglayer Smart Contracts](https://github.com/agglayer/agglayer-contracts) and the Agglayer protocol.
 
-- [Documentation link](https://expert-journey-9jzpgrg.pages.github.io/)
-- kanban board to track `Protocol` team tasks
+## 🛠️ Build Documentation
+Documentation is available with **MkDocs**.
 
-## Team members
-- Carlos @krlosMata
-- Laia @laisolizq
-- Jesús @invocamanman
-- Ignasi @ignasirv
-- Alvaro @alrevuelta
-
-## Repositories and owners
-- [zkevm-rom](https://github.com/0xPolygon/zkevm-rom)
-- [zkevm-commonjs](https://github.com/0xPolygon/zkevm-commonjs)
-- [zkevm-testvectors](https://github.com/0xPolygon/zkevm-testvectors)
-- [zkevm-proverjs](https://github.com/0xPolygon/zkevm-proverjs)
-- [ethereumjs-monorepo](https://github.com/0xPolygon/ethereumjs-monorepo)
-- [fork ethereum-tests](https://github.com/0xPolygon/ethereum-tests)
-- [agglayer-contracts](https://github.com/agglayer/agglayer-contracts/)
-
-## Notion
-- [Protocol team landing page](https://www.notion.so/polygontechnology/Protocol-team-b3ee0712a65b4558910bea2ed1aecf03)
-
-## Documentation
-Documentation is available with `mkdocs`
-
-### How to install and run
-````
+### 🚀 How to Install and Run
+```bash
 pip install mkdocs
 pip install -r requirements.txt
 mkdocs serve
-````
-
-A bash script has been added to easily import hackmd files to the mkdocs page:
-````
-sh addHackMD.sh
-````
-
-Just follow the cli instructions, to add more paths where to store files, you should create the folders manually directly inside the `/docs` path.
-Adding files manually is also supported
+```  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Protocol Documentation
+site_name: SC-Protocol Documentation
 repo_url: https://github.com/Agglayer/protocol-team-docs
 
 theme:


### PR DESCRIPTION
This pull request updates the documentation to provide a clearer and more focused introduction to the Protocol Team Docs, emphasizing Agglayer Smart Contracts and protocol documentation. The changes modernize the presentation, streamline instructions for building the docs, and update the site name for consistency.

**Documentation and Presentation Updates:**
* Revamped the `README.md` to use a visually prominent documentation link, removed outdated team and repository info, and clarified build instructions for MkDocs.
* Updated `docs/index.md` to match the new documentation focus, removing team and repository details and aligning build instructions with the README.

**Configuration Update:**
* Changed the documentation site name in `mkdocs.yml` from "Protocol Documentation" to "SC-Protocol Documentation" for improved clarity and branding.