### PR TITLE
improve outposts docs

### DIFF
--- a/docs/outposts/Intro.md
+++ b/docs/outposts/Intro.md
@@ -9,6 +9,16 @@
 - Has **its own finality**
 - All outposts will have a **customGasToken** that will be the native token of the chain
     - Outpost chains can not have native ether token
+    - Three key parameters configure the gas token: `gasTokenAddress`, `gasTokenNetwork`, and `gasTokenMetadata` (`abi.encode("Name", "Symbol", decimals)`)
+    - **External token** (e.g. the outpost's native ETH representation):
+        - `gasTokenAddress`: address on origin chain
+        - `gasTokenNetwork`: origin chain ID
+        - `gasTokenMetadata`: encoded metadata
+        - If an outpost has `L2_ETH` as a native token, it is not `L1_ETH` but its representation on the chain. If `L1_ETH` is set as the native token, the bridge must be funded with `L2_ETH` and effectively acts as a liquidity pool.
+    - **Native L2 token** (token originating on the outpost itself):
+        - `gasTokenAddress`: derived from rollupID — repeat rollupID (32 bits) 5x to form a 160-bit address, i.e. `0x{rollupID}{rollupID}{rollupID}{rollupID}{rollupID}`
+        - `gasTokenNetwork`: chain rollupID
+        - `gasTokenMetadata`: metadata shown when bridged to other chains
 - **Examples**:
     - Base
     - Optimism
@@ -88,6 +98,3 @@ sequenceDiagram
     L1_Agglayer_Bridge ->> User: mint wrappedBaseETH
     Note left of User: User has wrappedBaseETH ✅
 ```
-
-<br>
-<br>


### PR DESCRIPTION
This pull request updates the outpost documentation to clarify how gas tokens are configured and represented on outpost chains. The changes provide detailed explanations of the parameters used for gas token configuration and distinguish between external tokens and native L2 tokens.

Gas token configuration and representation:

* Added descriptions of three key parameters for gas token configuration: `gasTokenAddress`, `gasTokenNetwork`, and `gasTokenMetadata`, including how metadata is encoded.
* Explained the distinction between external tokens (such as an outpost's native ETH representation) and native L2 tokens, with details on address derivation and metadata usage.

Documentation cleanup:

* Removed unnecessary line breaks at the end of the `sequenceDiagram` section to tidy up the documentation.